### PR TITLE
Fix login redirect cookie to work in iframes

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         </script>
         <script>
             if (!document.cookie || !document.cookie.match(/(^|;)originURI=/gi))
-                document.cookie = "originURI=/login.html;SameSite=None" + (window.location.protocol === "https:" ? ";Secure" : "");
+                document.cookie = "originURI=/login.html" + (window.location.protocol === "https:" ? ";SameSite=None;Secure" : "");
         </script>
         <script src="mxclientsystem/mxui/mxui.js?{{cachebust}}"></script>
     </body>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         </script>
         <script>
             if (!document.cookie || !document.cookie.match(/(^|;)originURI=/gi))
-                document.cookie = "originURI=/login.html";
+                document.cookie = "originURI=/login.html;SameSite=None" + (window.location.protocol === "https:" ? ";Secure" : "");
         </script>
         <script src="mxclientsystem/mxui/mxui.js?{{cachebust}}"></script>
     </body>


### PR DESCRIPTION
Browsers are adding new default restrictions to cookies when a page is loaded within an iframe. By default they will block all cookies if the parent page and iframe source are on different sites. This means that if a Mendix app is loaded in an externally hosted iframe (e.g. a dashboard page) this cookie will be blocked and the login redirect will not work. By adding the `SameSite=None` and `Secure` options the restriction is lifted when on https: and the cookie will not be blocked.

(UICORE-744)