### PR TITLE
Fix dark mode date picker iOS

### DIFF
--- a/styles/native/js/core/widgets/datepicker.js
+++ b/styles/native/js/core/widgets/datepicker.js
@@ -1,5 +1,4 @@
-import { font, input } from "../variables";
-import { background } from "../../app/custom-variables";
+import { background, font, input } from "../variables";
 import { TextBox, TextBoxVertical } from "./textbox";
 /*
 

--- a/styles/native/js/core/widgets/datepicker.js
+++ b/styles/native/js/core/widgets/datepicker.js
@@ -22,9 +22,9 @@ export const DatePicker = {
         ...TextBox.label,
     },
     pickerIOS: {
-        // All ViewStyle properties & "textColor" (type: string) are allowed
+        // All ViewStyle properties & "color" (type: string) are allowed
         backgroundColor: background.primary,
-        textColor: font.color,
+        color: font.color,
     },
     pickerBackdropIOS: {
         // All ViewStyle properties are allowed

--- a/styles/native/js/core/widgets/datepicker.js
+++ b/styles/native/js/core/widgets/datepicker.js
@@ -1,4 +1,5 @@
 import { font, input } from "../variables";
+import { background } from "../../app/custom-variables";
 import { TextBox, TextBoxVertical } from "./textbox";
 /*
 
@@ -23,7 +24,7 @@ export const DatePicker = {
     },
     pickerIOS: {
         // All ViewStyle properties & "textColor" (type: string) are allowed
-        backgroundColor: input.backgroundColor,
+        backgroundColor: background.primary,
         textColor: font.color,
     },
     pickerBackdropIOS: {
@@ -31,7 +32,7 @@ export const DatePicker = {
     },
     pickerTopIOS: {
         // All ViewStyle properties are allowed
-        backgroundColor: input.backgroundColor,
+        backgroundColor: background.primary,
     },
     value: {
         // All TextStyle properties are allowed

--- a/styles/native/js/core/widgets/datepicker.js
+++ b/styles/native/js/core/widgets/datepicker.js
@@ -1,5 +1,3 @@
-import { NativeModules } from "react-native";
-import { darkMode } from "../../app/custom-variables";
 import { font, input } from "../variables";
 import { TextBox, TextBoxVertical } from "./textbox";
 /*
@@ -14,13 +12,6 @@ To customize any core styling, copy the part you want to customize to styles/nat
 
     Default Class For Mendix Date Picker Widget
 ========================================================================== */
-// Font color of native iOS datepicker can not be changed.
-// To fix this we change the background color of the picker if OS theme is dark and app theme is light (And the other way around).
-const isOSDarkMode = NativeModules && NativeModules.RNDarkMode && NativeModules.RNDarkMode.initialMode && NativeModules.RNDarkMode.initialMode === "dark";
-const pickerBackgroundColor = !darkMode && isOSDarkMode ?
-    "rgba(0, 0, 0, 1)" :
-    darkMode && !isOSDarkMode ? "rgba(255, 255, 255, 1)" : input.backgroundColor;
-//
 export const DatePicker = {
     container: {
         // All ViewStyle properties are allowed
@@ -31,15 +22,16 @@ export const DatePicker = {
         ...TextBox.label,
     },
     pickerIOS: {
-        // All ViewStyle properties are allowed
-        backgroundColor: pickerBackgroundColor,
+        // All ViewStyle properties & "textColor" (type: string) are allowed
+        backgroundColor: input.backgroundColor,
+        textColor: font.color,
     },
     pickerBackdropIOS: {
-    // All ViewStyle properties are allowed
+        // All ViewStyle properties are allowed
     },
     pickerTopIOS: {
         // All ViewStyle properties are allowed
-        backgroundColor: pickerBackgroundColor,
+        backgroundColor: input.backgroundColor,
     },
     value: {
         // All TextStyle properties are allowed
@@ -62,7 +54,7 @@ export const DatePicker = {
         color: input.placeholderTextColor,
     },
     placeholderDisabled: {
-    // All TextStyle properties are allowed
+        // All TextStyle properties are allowed
     },
     validationMessage: {
         // All TextStyle properties are allowed

--- a/styles/native/ts/core/widgets/datepicker.ts
+++ b/styles/native/ts/core/widgets/datepicker.ts
@@ -1,8 +1,6 @@
-import { NativeModules }            from "react-native";
-import { darkMode }                 from "../../app/custom-variables";
-import { font, input }              from "../variables";
+import { font, input } from "../variables";
 import { TextBox, TextBoxVertical } from "./textbox";
-import { DatePickerType }           from "../../types/widgets";
+import { DatePickerType } from "../../types/widgets";
 /*
 
 DISCLAIMER:
@@ -15,13 +13,6 @@ To customize any core styling, copy the part you want to customize to styles/nat
 
     Default Class For Mendix Date Picker Widget
 ========================================================================== */
-// Font color of native iOS datepicker can not be changed.
-// To fix this we change the background color of the picker if OS theme is dark and app theme is light (And the other way around).
-const isOSDarkMode = NativeModules && NativeModules.RNDarkMode && NativeModules.RNDarkMode.initialMode && NativeModules.RNDarkMode.initialMode === "dark";
-const pickerBackgroundColor = !darkMode && isOSDarkMode ?
-                              "rgba(0, 0, 0, 1)" :
-                              darkMode && !isOSDarkMode ? "rgba(255, 255, 255, 1)" : input.backgroundColor;
-//
 export const DatePicker: DatePickerType = {
     container: {
         // All ViewStyle properties are allowed
@@ -32,15 +23,16 @@ export const DatePicker: DatePickerType = {
         ...TextBox.label,
     },
     pickerIOS: {
-        // All ViewStyle properties are allowed
-        backgroundColor: pickerBackgroundColor,
+        // All ViewStyle properties & "textColor" (type: string) are allowed
+        backgroundColor: input.backgroundColor,
+        textColor: font.color,
     },
     pickerBackdropIOS: {
         // All ViewStyle properties are allowed
     },
     pickerTopIOS: {
         // All ViewStyle properties are allowed
-        backgroundColor: pickerBackgroundColor,
+        backgroundColor: input.backgroundColor,
     },
     value: {
         // All TextStyle properties are allowed

--- a/styles/native/ts/core/widgets/datepicker.ts
+++ b/styles/native/ts/core/widgets/datepicker.ts
@@ -1,4 +1,5 @@
 import { font, input } from "../variables";
+import { background } from "../../app/custom-variables";
 import { TextBox, TextBoxVertical } from "./textbox";
 import { DatePickerType } from "../../types/widgets";
 /*
@@ -24,7 +25,7 @@ export const DatePicker: DatePickerType = {
     },
     pickerIOS: {
         // All ViewStyle properties & "textColor" (type: string) are allowed
-        backgroundColor: input.backgroundColor,
+        backgroundColor: background.primary,
         textColor: font.color,
     },
     pickerBackdropIOS: {
@@ -32,7 +33,7 @@ export const DatePicker: DatePickerType = {
     },
     pickerTopIOS: {
         // All ViewStyle properties are allowed
-        backgroundColor: input.backgroundColor,
+        backgroundColor: background.primary,
     },
     value: {
         // All TextStyle properties are allowed

--- a/styles/native/ts/core/widgets/datepicker.ts
+++ b/styles/native/ts/core/widgets/datepicker.ts
@@ -1,5 +1,4 @@
-import { font, input } from "../variables";
-import { background } from "../../app/custom-variables";
+import { background, font, input } from "../variables";
 import { TextBox, TextBoxVertical } from "./textbox";
 import { DatePickerType } from "../../types/widgets";
 /*

--- a/styles/native/ts/core/widgets/datepicker.ts
+++ b/styles/native/ts/core/widgets/datepicker.ts
@@ -23,9 +23,9 @@ export const DatePicker: DatePickerType = {
         ...TextBox.label,
     },
     pickerIOS: {
-        // All ViewStyle properties & "textColor" (type: string) are allowed
+        // All ViewStyle properties & "color" (type: string) are allowed
         backgroundColor: background.primary,
-        textColor: font.color,
+        color: font.color,
     },
     pickerBackdropIOS: {
         // All ViewStyle properties are allowed

--- a/styles/native/ts/types/widgets.d.ts
+++ b/styles/native/ts/types/widgets.d.ts
@@ -139,7 +139,9 @@ export interface ContainerType {
 export interface DatePickerType {
     container?: ViewStyle,
     label?: InputLabelType,
-    pickerIOS?: ViewStyle,
+    pickerIOS?: {
+                    color?: string
+                } & ViewStyle,
     pickerBackdropIOS?: ViewStyle,
     pickerTopIOS?: ViewStyle,
     value?: TextStyle,


### PR DESCRIPTION
- The text color of the native iOS date picker is now adjustable.
- Date picker now always follows the dark mode setting of Atlas. Previously, when dark mode in Atlas was set to 'true' or 'false', date picker would still reflect the dark mode setting of iOS. This was due to the text color switching automatically based on the iOS dark mode setting and text color not being adjustable through styling.