### PR TITLE
Native dropdown menu item styling

### DIFF
--- a/styles/native/js/app/custom-variables.js
+++ b/styles/native/js/app/custom-variables.js
@@ -156,6 +156,7 @@ export const input = {
     selectionColor: contrast.lower,
     placeholderTextColor: contrast.regular,
     underlineColorAndroid: "transparent",
+    inputContainerUnderlayColor: `rgba(${anyColorToRgbString(contrast.low)},0.4)`,
     // Sizes
     fontSize: font.size,
     fontFamily: font.family,

--- a/styles/native/js/core/variables.js
+++ b/styles/native/js/core/variables.js
@@ -156,6 +156,7 @@ let input = {
     selectionColor: contrast.lower,
     placeholderTextColor: contrast.regular,
     underlineColorAndroid: "transparent",
+    inputContainerUnderlayColor: `rgba(${anyColorToRgbString(contrast.low)},0.4)`,
     // Sizes
     fontSize: font.size,
     fontFamily: font.family,

--- a/styles/native/js/core/widgets/dropdown.js
+++ b/styles/native/js/core/widgets/dropdown.js
@@ -52,7 +52,7 @@ export const DropDown = {
     },
     /*  New dropdown styles start */
     valueContainer: {
-    // All ViewStyle properties & rippleColor are allowed
+    // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
     },
     valueContainerDisabled: {
     // All ViewStyle properties are allowed
@@ -67,11 +67,12 @@ export const DropDown = {
         backgroundColor: input.backgroundColor,
     },
     itemContainer: {
-        // All ViewStyle properties are allowed
+        // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
         maxWidth: 500,
         paddingVertical: 6,
         paddingHorizontal: 16,
         backgroundColor: input.backgroundColor,
+        underlayColor: contrast.low,
     },
     item: {
         // All TextStlye properties are allowed

--- a/styles/native/js/core/widgets/dropdown.js
+++ b/styles/native/js/core/widgets/dropdown.js
@@ -72,7 +72,7 @@ export const DropDown = {
         paddingVertical: 6,
         paddingHorizontal: 16,
         backgroundColor: input.backgroundColor,
-        underlayColor: contrast.low,
+        underlayColor: input.inputContainerUnderlayColor,
     },
     item: {
         // All TextStlye properties are allowed

--- a/styles/native/js/core/widgets/referenceselector.js
+++ b/styles/native/js/core/widgets/referenceselector.js
@@ -66,6 +66,7 @@ export const ReferenceSelector = {
         shadowOpacity: 0.2,
         shadowRadius: 10,
         elevation: 16,
+        backgroundColor: input.backgroundColor
     },
     itemContainer: {
         // All ViewStyle properties are allowed

--- a/styles/native/js/core/widgets/referenceselector.js
+++ b/styles/native/js/core/widgets/referenceselector.js
@@ -73,6 +73,7 @@ export const ReferenceSelector = {
         paddingVertical: 6,
         paddingHorizontal: 16,
         backgroundColor: input.backgroundColor,
+        underlayColor: input.inputContainerUnderlayColor,
     },
     item: {
         // All TextStyle properties are allowed

--- a/styles/native/js/core/widgets/referenceselector.js
+++ b/styles/native/js/core/widgets/referenceselector.js
@@ -54,7 +54,7 @@ export const ReferenceSelector = {
     },
     /*  New dropdown styles start */
     valueContainer: {
-    // All ViewStyle properties & rippleColor are allowed
+    // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
     },
     valueContainerDisabled: {
     // All ViewStyle properties are allowed
@@ -69,7 +69,7 @@ export const ReferenceSelector = {
         backgroundColor: input.backgroundColor
     },
     itemContainer: {
-        // All ViewStyle properties are allowed
+        // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
         maxWidth: 500,
         paddingVertical: 6,
         paddingHorizontal: 16,

--- a/styles/native/ts/app/custom-variables.ts
+++ b/styles/native/ts/app/custom-variables.ts
@@ -175,6 +175,7 @@ export const input: VariablesInput = {
     selectionColor: contrast.lower,
     placeholderTextColor: contrast.regular,
     underlineColorAndroid: "transparent",
+    inputContainerUnderlayColor: `rgba(${anyColorToRgbString(contrast.low)},0.4)`,
 
     // Sizes
     fontSize: font.size,

--- a/styles/native/ts/core/variables.ts
+++ b/styles/native/ts/core/variables.ts
@@ -172,6 +172,7 @@ let input: VariablesInput = {
     selectionColor: contrast.lower,
     placeholderTextColor: contrast.regular,
     underlineColorAndroid: "transparent",
+    inputContainerUnderlayColor: `rgba(${anyColorToRgbString(contrast.low)},0.4)`,
 
     // Sizes
     fontSize: font.size,

--- a/styles/native/ts/core/widgets/dropdown.ts
+++ b/styles/native/ts/core/widgets/dropdown.ts
@@ -56,7 +56,7 @@ export const DropDown: DropDownType = {
     },
     /*  New dropdown styles start */
     valueContainer: {
-        // All ViewStyle properties & rippleColor are allowed
+        // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
     },
     valueContainerDisabled: {
         // All ViewStyle properties are allowed
@@ -71,11 +71,12 @@ export const DropDown: DropDownType = {
         backgroundColor: input.backgroundColor,
     },
     itemContainer: {
-        // All ViewStyle properties are allowed
+        // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
         maxWidth: 500,
         paddingVertical: 6,
         paddingHorizontal: 16,
         backgroundColor: input.backgroundColor,
+        underlayColor: contrast.low,
     },
     item: {
         // All TextStlye properties are allowed

--- a/styles/native/ts/core/widgets/dropdown.ts
+++ b/styles/native/ts/core/widgets/dropdown.ts
@@ -76,7 +76,7 @@ export const DropDown: DropDownType = {
         paddingVertical: 6,
         paddingHorizontal: 16,
         backgroundColor: input.backgroundColor,
-        underlayColor: contrast.low,
+        underlayColor: input.inputContainerUnderlayColor,
     },
     item: {
         // All TextStlye properties are allowed

--- a/styles/native/ts/core/widgets/referenceselector.ts
+++ b/styles/native/ts/core/widgets/referenceselector.ts
@@ -77,6 +77,7 @@ export const ReferenceSelector: DropDownType = {
         paddingVertical: 6,
         paddingHorizontal: 16,
         backgroundColor: input.backgroundColor,
+        underlayColor: input.inputContainerUnderlayColor,
     },
     item: {
         // All TextStyle properties are allowed

--- a/styles/native/ts/core/widgets/referenceselector.ts
+++ b/styles/native/ts/core/widgets/referenceselector.ts
@@ -58,7 +58,7 @@ export const ReferenceSelector: DropDownType = {
     },
     /*  New dropdown styles start */
     valueContainer: {
-        // All ViewStyle properties & rippleColor are allowed
+        // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
     },
     valueContainerDisabled: {
         // All ViewStyle properties are allowed
@@ -73,7 +73,7 @@ export const ReferenceSelector: DropDownType = {
         backgroundColor: input.backgroundColor
     },
     itemContainer: {
-        // All ViewStyle properties are allowed
+        // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
         maxWidth: 500,
         paddingVertical: 6,
         paddingHorizontal: 16,

--- a/styles/native/ts/core/widgets/referenceselector.ts
+++ b/styles/native/ts/core/widgets/referenceselector.ts
@@ -70,6 +70,7 @@ export const ReferenceSelector: DropDownType = {
         shadowOpacity: 0.2,
         shadowRadius: 10,
         elevation: 16,
+        backgroundColor: input.backgroundColor
     },
     itemContainer: {
         // All ViewStyle properties are allowed

--- a/styles/native/ts/types/variables.d.ts
+++ b/styles/native/ts/types/variables.d.ts
@@ -2,8 +2,6 @@
     Types
 ========================================================================== */
 
-import { badge, font } from "../app/custom-variables";
-
 declare type FontWeight = "normal" | "bold" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900";
 declare type TextAlign = "auto" | "left" | "right" | "center" | "justify";
 declare type TextTransform = "none" | "capitalize" | "uppercase" | "lowercase";
@@ -124,6 +122,7 @@ export interface VariablesInput {
     selectionColor: string,
     placeholderTextColor: string,
     underlineColorAndroid: string,
+    inputContainerUnderlayColor: string,
 
     fontSize: number,
     fontFamily: string,

--- a/styles/native/ts/types/widgets.d.ts
+++ b/styles/native/ts/types/widgets.d.ts
@@ -173,13 +173,19 @@ export interface DropDownType {
     valueDisabled?: TextStyle,
     validationMessage?: TextStyle,
     /*  New dropdown styles start */
-    valueContainer?: {
-                         rippleColor?: string
-                     } & ViewStyle;
+    valueContainer?: ViewStyle & {
+        rippleColor?: string;
+        underlayColor?: string;
+        activeOpacity?: number;
+    };
     valueContainerDisabled?: ViewStyle;
     menuWrapper?: ViewStyle;
     item?: TextStyle;
-    itemContainer?: ViewStyle;
+    itemContainer?: ViewStyle & {
+        rippleColor?: string;
+        underlayColor?: string;
+        activeOpacity?: number;
+    };
     selectedItem?: TextStyle;
     selectedItemContainer?: ViewStyle;
     /*  New dropdown styles end */


### PR DESCRIPTION
# Overview

Native Dropdown (Uniform) menu items on iOS in dark mode had two issues:

- if you pressed the selected item it would flash white, essentially due to Atlas missing an `underlayColor` property and the 3rd-party component previously defaulting this to white-ish. 

- the `underlayColor` would "bleed" out of the edges, essentially due to how the previously used 3rd-party component would include a `View` component as a child to the `TouchableHighlight`. 

This has been corrected with this changeset, by correcting styling and introducing an implementation of MenuItem.

This includes a bonus fix for reference selector's `backgroundColor` when in horizontal layout, to fix an issue for iOS when in dark mode.

# To Test

- Android and iOS (light + dark) native Dropdown styling (Atlas 2)
- No regression in native ReferenceSelector styling (which uses DropdownUniform)
  - Both alignments (horizontal and verticle) for Dropdown and Reference Selector are styled are expected

NN