### PR TITLE
Add missing colour styling property for Dropdown Uniform icon

### DIFF
--- a/styles/native/ts/core/widgets/dropdown.ts
+++ b/styles/native/ts/core/widgets/dropdown.ts
@@ -86,6 +86,7 @@ export const DropDown: DropDownType = {
     },
     iconStyle: {
         // All TextStyle properties are allowed
+        color: input.color
     },
     item: {
         // All TextStlye properties are allowed

--- a/styles/native/ts/core/widgets/referenceselector.ts
+++ b/styles/native/ts/core/widgets/referenceselector.ts
@@ -1,5 +1,5 @@
 import { border, contrast, font, input } from "../variables";
-import { DropDownVertical }                      from "./dropdown";
+import { DropDownVertical }              from "./dropdown";
 import { TextBox, TextBoxVertical }      from "./textbox";
 import { DropDownType }                  from "../../types/widgets";
 /*
@@ -88,6 +88,7 @@ export const ReferenceSelector: DropDownType = {
     },
     iconStyle: {
         // All TextStyle properties are allowed
+        color: input.color
     },
     item: {
         // All TextStyle properties are allowed


### PR DESCRIPTION
Add explicit text colour applicable to iOS when in Dark Mode. 

