### PR TITLE
Remove old top bar reference

### DIFF
--- a/styles/native/js/core/widgets/navigation.js
+++ b/styles/native/js/core/widgets/navigation.js
@@ -7,9 +7,9 @@ Customizing core files will make updating Atlas much more difficult in the futur
 To customize any core styling, copy the part you want to customize to styles/native/app/ so the core styling is overwritten.
 
 ==========================================================================
-    TopBar / BottomBar / ProgressOverlay
+    BottomBar / ProgressOverlay
 
-    Default Class For Mendix TopBar, BottomBar and ProgressOverlay
+    Default Class For Mendix BottomBar and ProgressOverlay
 ========================================================================== */
 export const navigationStyle = {
     bottomBar: {

--- a/styles/native/ts/core/widgets/navigation.ts
+++ b/styles/native/ts/core/widgets/navigation.ts
@@ -8,9 +8,9 @@ Customizing core files will make updating Atlas much more difficult in the futur
 To customize any core styling, copy the part you want to customize to styles/native/app/ so the core styling is overwritten.
 
 ==========================================================================
-    TopBar / BottomBar / ProgressOverlay
+    BottomBar / ProgressOverlay
 
-    Default Class For Mendix TopBar, BottomBar and ProgressOverlay
+    Default Class For Mendix BottomBar and ProgressOverlay
 ========================================================================== */
 export const navigationStyle: NavigationType = {
     bottomBar: {


### PR DESCRIPTION
Something found during testing that could be confusing to users:

The top bar is no longer styleable through the navigationStyle class, so it can be removed from the comment to prevent confusion.