### PR TITLE
Allow targeting login header

### DIFF
--- a/login-with-sso.html
+++ b/login-with-sso.html
@@ -21,7 +21,7 @@
             </div>
             <div class="loginpage-right">
                 <div class="loginpage-formwrapper">
-                    <h2>Sign in</h2>
+                    <h2 id="loginHeader">Sign in</h2>
                     <form id="loginForm" class="loginpage-form" autocomplete="off">
                         <div>
                             <div id="loginMessage" class="alert alert-danger"></div>

--- a/login.html
+++ b/login.html
@@ -21,7 +21,7 @@
             </div>
             <div class="loginpage-right">
                 <div class="loginpage-formwrapper">
-                    <h2>Sign in</h2>
+                    <h2 id="loginHeader">Sign in</h2>
                     <form id="loginForm" class="loginpage-form" autocomplete="off">
                         <div>
                             <div id="loginMessage" class="alert alert-danger"></div>


### PR DESCRIPTION
## Why?

The login pages have a header "Sign in" which now has an ID that the login.js script can target for translations.