### PR TITLE
Release 2.6.8

### DIFF
--- a/login-with-sso.html
+++ b/login-with-sso.html
@@ -21,7 +21,7 @@
             </div>
             <div class="loginpage-right">
                 <div class="loginpage-formwrapper">
-                    <h2>Sign in</h2>
+                    <h2 id="loginHeader">Sign in</h2>
                     <form id="loginForm" class="loginpage-form" autocomplete="off">
                         <div>
                             <div id="loginMessage" class="alert alert-danger"></div>

--- a/login.html
+++ b/login.html
@@ -21,7 +21,7 @@
             </div>
             <div class="loginpage-right">
                 <div class="loginpage-formwrapper">
-                    <h2>Sign in</h2>
+                    <h2 id="loginHeader">Sign in</h2>
                     <form id="loginForm" class="loginpage-form" autocomplete="off">
                         <div>
                             <div id="loginMessage" class="alert alert-danger"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "atlas-ui-framework",
-    "version": "2.6.7",
+    "version": "2.6.8",
     "description": "Mendix Atlas UI is the foundation of making beautiful apps with Mendix. For more information about the framework go to https://atlas.mendix.com.",
     "main": "",
     "scripts": {


### PR DESCRIPTION
- Add `id` to login pages "Sign In" header that is targeted for translations