### PR TITLE
[NC-312] Dropdown width

### DIFF
--- a/styles/native/ts/core/widgets/dropdown.ts
+++ b/styles/native/ts/core/widgets/dropdown.ts
@@ -79,7 +79,6 @@ export const DropDown: DropDownType = {
     },
     itemContainer: {
         // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
-        maxWidth: 500,
         paddingVertical: 6,
         paddingHorizontal: 16,
         backgroundColor: input.backgroundColor,

--- a/styles/native/ts/core/widgets/dropdown.ts
+++ b/styles/native/ts/core/widgets/dropdown.ts
@@ -79,6 +79,8 @@ export const DropDown: DropDownType = {
     },
     itemContainer: {
         // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
+        width: "100%",
+        maxWidth: undefined, // unset core widget's default maxWidth value (prior to 8.18.7)
         paddingVertical: 6,
         paddingHorizontal: 16,
         backgroundColor: input.backgroundColor,
@@ -98,6 +100,8 @@ export const DropDown: DropDownType = {
     },
     selectedItemContainer: {
         // All ViewStyle properties are allowed
+        width: "100%",
+        maxWidth: undefined, // unset core widget's default maxWidth value (prior to 8.18.7)
         backgroundColor: contrast.lowest,
     },
     /*  New dropdown styles end */

--- a/styles/native/ts/core/widgets/referenceselector.ts
+++ b/styles/native/ts/core/widgets/referenceselector.ts
@@ -81,7 +81,6 @@ export const ReferenceSelector: DropDownType = {
     },
     itemContainer: {
         // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
-        maxWidth: 500,
         paddingVertical: 6,
         paddingHorizontal: 16,
         backgroundColor: input.backgroundColor,

--- a/styles/native/ts/core/widgets/referenceselector.ts
+++ b/styles/native/ts/core/widgets/referenceselector.ts
@@ -81,6 +81,8 @@ export const ReferenceSelector: DropDownType = {
     },
     itemContainer: {
         // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
+        width: "100%",
+        maxWidth: undefined, // unset core widget's default maxWidth value (prior to 8.18.7)
         paddingVertical: 6,
         paddingHorizontal: 16,
         backgroundColor: input.backgroundColor,
@@ -100,6 +102,8 @@ export const ReferenceSelector: DropDownType = {
     },
     selectedItemContainer: {
         // All ViewStyle properties are allowed
+        width: "100%",
+        maxWidth: undefined, // unset core widget's default maxWidth value (prior to 8.18.7)
         backgroundColor: contrast.lowest,
     },
     /*  New dropdown styles end */


### PR DESCRIPTION
## What is the purpose of this PR?
### Feature: 

Remove `maxWidth` here in Atlas and add `width: "100%"` in client code for dropdowns so that they take up all available width of their parent.

Atlas set dropdown's `maxWidth` to 500. Why? Neither Wesley or I know why 500 was chosen. Based on customer feedback, when the device viewport is large, customers expect the menu items to be the same width as the element that renders the selected value. This change ensures that.

## What should be covered while testing?
Native dropdown renders appropriately in different modelled scenarios.