### PR TITLE
Floating Action Button dark mode styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "atlas-ui-framework",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "Mendix Atlas UI is the foundation of making beautiful apps with Mendix. For more information about the framework go to https://atlas.mendix.com.",
     "main": "",
     "scripts": {

--- a/styles/native/ts/core/widgets/floatingactionbutton.ts
+++ b/styles/native/ts/core/widgets/floatingactionbutton.ts
@@ -1,5 +1,6 @@
 import { FloatingActionButtonType } from "../../types/widgets";
 import { background, brand, contrast, font } from "../variables";
+import { darkMode } from "../../app/custom-variables"
 /*
 
 DISCLAIMER:
@@ -67,6 +68,8 @@ export const com_mendix_widget_native_floatingactionbutton_FloatingActionButton:
     secondaryButtonCaptionContainer: {
         // All ViewStyle properties are allowed
         marginHorizontal: 5,
+        backgroundColor: background.secondary,
+        borderColor: darkMode ? background.secondary : "#eee",
         elevation: 2,
         shadowOpacity: 0.3,
         shadowRadius: 4,

--- a/styles/native/ts/core/widgets/floatingactionbutton.ts
+++ b/styles/native/ts/core/widgets/floatingactionbutton.ts
@@ -1,6 +1,6 @@
 import { FloatingActionButtonType } from "../../types/widgets";
 import { background, brand, contrast, font } from "../variables";
-import { darkMode } from "../../app/custom-variables"
+
 /*
 
 DISCLAIMER:
@@ -69,7 +69,7 @@ export const com_mendix_widget_native_floatingactionbutton_FloatingActionButton:
         // All ViewStyle properties are allowed
         marginHorizontal: 5,
         backgroundColor: background.secondary,
-        borderColor: darkMode ? background.secondary : "#eee",
+        borderColor: background.secondary,
         elevation: 2,
         shadowOpacity: 0.3,
         shadowRadius: 4,


### PR DESCRIPTION
## What is the purpose of this PR?
The FAB widget's style in dark mode is not expected. The border is a light color.

The FAB widget [defaults](https://github.com/mastermoo/react-native-action-button/blob/master/ActionButtonItem.js#L208) to a white/grey-ish border color unless it is specified. 

An explicit border color has been added to Atlas.

## What should be covered while testing?
Does the styling take affect with an updated Atlas, in both light and dark mode?

## Extra comments (optional)
The wiget itself (without Atlas) has its own default styling however these are very minimal and don't support dark mode. End-users must use Atlas to get "advanced" styling that supports dark mode.